### PR TITLE
Stop in season matchups

### DIFF
--- a/app/modules/baseball_standings_router_template.js
+++ b/app/modules/baseball_standings_router_template.js
@@ -190,7 +190,7 @@ module.exports = function(req, res, db, year, playoffs) {
 				}
 
 				// run standings.py from python-shell to update collections with roto and trifecta points
-				pyshell.run("baseball_standings.py", options, function(err) {
+				pyshell.run("python/baseball_standings.py", options, function(err) {
 					
 					if (err) throw err;
 					console.log("Python script complete");

--- a/app/routes/matchups.js
+++ b/app/routes/matchups.js
@@ -8,6 +8,240 @@ let pyshell = require('python-shell');
 let mongo = require('mongodb');
 let assert = require('assert');
 
+function display_owner_matchups(req, res, db, args) {
+	let owner_number = args.owner_number;
+	let current_year1 = args.current_year1;
+	let current_year2 = args.current_year2;
+	let year1 = args.year1;
+	let year2 = args.year2;
+	let this_football_completed_season = args.this_football_completed_season;
+	let this_basketball_completed_season = args.this_basketball_completed_season;
+	let this_baseball_completed_season = args.this_baseball_completed_season;
+
+	let year_diff = year2 - year1;
+
+	let disp_football_matchups = null;
+	let disp_basketball_matchups = null;
+	let disp_baseball_matchups = null;
+	let disp_trifecta_matchups = null;
+
+// display function that when all individual in seaason sports have been pulled
+var display = function(sports_number) {
+
+		if (sports_number === 3) {
+			// if all of the necessary matchup documents are filled
+			if ((disp_football_matchups != null && disp_basketball_matchups != null) && disp_baseball_matchups != null) {
+
+				// pull owner's name for all pulls and/or scrapes
+				db.collection('owner' + owner_number).find({}, {"owner": 1,"teams": 1, "_id": 0}).toArray(function(e, docs) {
+					owner_name = docs[0]["owner"];
+					//console.log(owner_name);
+
+					// set python arguments
+					var options = {
+						args: [owner_number, year1, year2, this_football_completed_season, this_basketball_completed_season, this_baseball_completed_season]
+					}
+
+					// read total trifecta season matchup collection
+					db.collection('owner' + owner_number + '_trifecta_matchups_' + year1 + '_' + year2).find({}, {"_id": 0}).sort({"total_win_per": -1}).toArray(function(e, docs) {
+						console.log("Displaying Trifecta owner matchups...");
+						console.log("");
+						var disp_trifecta_matchups = docs;
+
+						// render owner_matchups
+						res.render('owner_matchups', {
+							year1: year1, 
+							year2: year2,
+							owner: owner_name,
+							football_matchups: disp_football_matchups,
+							basketball_matchups: disp_basketball_matchups,
+							baseball_matchups: disp_baseball_matchups,
+							football_in_season: this_football_completed_season,
+							basketball_in_season: this_basketball_completed_season,
+							baseball_in_season: this_baseball_completed_season,
+							trifecta_matchups: disp_trifecta_matchups
+						})
+
+					}) // end of trifecta matchups read
+				}) // end of owner_name scrape
+			}
+		} // end of if 3 sports
+
+		else if (sports_number === 2) {
+			if (disp_football_matchups != null && disp_basketball_matchups != null) {
+
+				// pull owner's name for all pulls and/or scrapes
+				db.collection('owner' + owner_number).find({}, {"owner": 1,"teams": 1, "_id": 0}).toArray(function(e, docs) {
+					owner_name = docs[0]["owner"];
+					//console.log(owner_name);
+
+					// set python arguments
+					var options = {
+						args: [owner_number, year1, year2, this_football_completed_season, this_basketball_completed_season, this_baseball_completed_season]
+					}
+
+					// read total trifecta season matchup collection
+					db.collection('owner' + owner_number + '_trifecta_matchups_' + year1 + '_' + year2).find({}, {"_id": 0}).sort({"total_win_per": -1}).toArray(function(e, docs) {
+						console.log("Displaying Trifecta owner matchups...");
+						console.log("");
+						var disp_trifecta_matchups = docs;
+
+						// render owner_matchups
+						res.render('owner_matchups', {
+							year1: year1, 
+							year2: year2,
+							owner: owner_name,
+							football_matchups: disp_football_matchups,
+							basketball_matchups: disp_basketball_matchups,
+							baseball_matchups: disp_baseball_matchups,
+							football_in_season: this_football_completed_season,
+							basketball_in_season: this_basketball_completed_season,
+							baseball_in_season: this_baseball_completed_season,
+							trifecta_matchups: disp_trifecta_matchups
+						})
+
+					}) // end of trifecta matchups read
+				}) // end of owner_name scrape
+			}
+		} // end of if 2 sports
+
+		else if (sports_number === 1) {
+			if (disp_football_matchups != null) {
+				// pull owner's name for all pulls and/or scrapes
+				db.collection('owner' + owner_number).find({}, {"owner": 1,"teams": 1, "_id": 0}).toArray(function(e, docs) {
+					owner_name = docs[0]["owner"];
+					//console.log(owner_name);
+
+					// set python arguments
+					var options = {
+						args: [owner_number, year1, year2, this_football_completed_season, this_basketball_completed_season, this_baseball_completed_season]
+					}
+
+					// read total trifecta season matchup collection
+					db.collection('owner' + owner_number + '_trifecta_matchups_' + year1 + '_' + year2).find({}, {"_id": 0}).sort({"total_win_per": -1}).toArray(function(e, docs) {
+						console.log("Displaying Trifecta owner matchups...");
+						console.log("");
+						var disp_trifecta_matchups = docs;
+
+						// render owner_matchups
+						res.render('owner_matchups', {
+							year1: year1, 
+							year2: year2,
+							owner: owner_name,
+							football_matchups: disp_football_matchups,
+							basketball_matchups: disp_basketball_matchups,
+							baseball_matchups: disp_baseball_matchups,
+							football_in_season: this_football_completed_season,
+							basketball_in_season: this_basketball_completed_season,
+							baseball_in_season: this_baseball_completed_season,
+							trifecta_matchups: disp_trifecta_matchups
+						})
+
+					}) // end of trifecta matchups read
+				}) // end of owner_name scrape
+			}
+		} // end of if 1 sport
+
+} // end of display function definition	
+	
+	// if incorrect years entered
+	if (year_diff != 1) {
+		res.send("Please enter two consecutive years"); 
+	}
+
+	// if years in the past all sports finished and pull
+	else if (year1 < current_year1 && year2 < current_year2) {
+		let sports_number = 3;
+		// pull from mongodb and display new data after python script finishes, but wait 2 seconds to let mongodb finish
+		db.collection('owner' + owner_number + '_football_matchups_' + year1).find({}, {"_id": 0}, {"sort": [["win_per", "desc"], ["pt_diff", "desc"]]}).toArray(function(e, docs) {
+			//console.log(docs);
+			//console.log("Displaying football matchup data...")
+			disp_football_matchups = docs;
+			// call display to see if all finds are done
+			display(sports_number);
+		});
+
+		db.collection("owner" + owner_number + "_basketball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
+			//console.log(docs);
+			//console.log("Displaying basketball matchup data...")
+			disp_basketball_matchups = docs;
+			// call display to see if all finds are done
+			display(sports_number);
+		});
+
+		db.collection("owner" + owner_number + "_baseball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
+			//console.log(docs);
+			//console.log("Displaying baseball matchup data...")
+			disp_baseball_matchups = docs;
+			// call display to see if all finds are done
+			display(sports_number);
+		});			
+	}
+
+	// if current trifecta season, only pull seasons that are completed
+	else {
+		if (this_baseball_completed_season == true) {
+			let sports_number = 3;
+			// pull from mongodb and display new data after python script finishes, but wait 2 seconds to let mongodb finish
+			db.collection('owner' + owner_number + '_football_matchups_' + year1).find({}, {"_id": 0}, {"sort": [["win_per", "desc"], ["pt_diff", "desc"]]}).toArray(function(e, docs) {
+				//console.log(docs);
+				//console.log("Displaying football matchup data...")
+				disp_football_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});
+
+			db.collection("owner" + owner_number + "_basketball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
+				//console.log(docs);
+				//console.log("Displaying basketball matchup data...")
+				disp_basketball_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});
+
+			db.collection("owner" + owner_number + "_baseball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
+				//console.log(docs);
+				//console.log("Displaying baseball matchup data...")
+				disp_baseball_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});				
+		}
+
+		else if (this_basketball_completed_season == true) {
+			let sports_number = 2;
+			// pull from mongodb and display new data after python script finishes, but wait 2 seconds to let mongodb finish
+			db.collection('owner' + owner_number + '_football_matchups_' + year1).find({}, {"_id": 0}, {"sort": [["win_per", "desc"], ["pt_diff", "desc"]]}).toArray(function(e, docs) {
+				//console.log(docs);
+				console.log("Displaying football matchup data...")
+				disp_football_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});
+
+			db.collection("owner" + owner_number + "_basketball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
+				//console.log(docs);
+				console.log("Displaying basketball matchup data...")
+				disp_basketball_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});
+
+		}
+
+		else if (this_football_completed_season == true) {
+			let sports_number = 1;
+			db.collection('owner' + owner_number + '_football_matchups_' + year1).find({}, {"_id": 0}, {"sort": [["win_per", "desc"], ["pt_diff", "desc"]]}).toArray(function(e, docs) {
+				//console.log(docs);
+				//console.log("Displaying football matchup data...")
+				disp_football_matchups = docs;
+				// call display to see if all finds are done
+				display(sports_number);
+			});			
+		}
+	}
+} // end of display_owners_matchup function
+
 
 function owner_matchups(req, res, db, args, football_args, basketball_args, baseball_args) {
 
@@ -250,6 +484,7 @@ var complete = function() {
 }
 
 module.exports = {
+	display_owner_matchups,
 	owner_matchups,
 	all_owner_matchups
 };

--- a/app/routes/matchups.js
+++ b/app/routes/matchups.js
@@ -213,7 +213,7 @@ var display = function(sports_number) {
 			// pull from mongodb and display new data after python script finishes, but wait 2 seconds to let mongodb finish
 			db.collection('owner' + owner_number + '_football_matchups_' + year1).find({}, {"_id": 0}, {"sort": [["win_per", "desc"], ["pt_diff", "desc"]]}).toArray(function(e, docs) {
 				//console.log(docs);
-				console.log("Displaying football matchup data...")
+				//console.log("Displaying football matchup data...")
 				disp_football_matchups = docs;
 				// call display to see if all finds are done
 				display(sports_number);
@@ -221,7 +221,7 @@ var display = function(sports_number) {
 
 			db.collection("owner" + owner_number + "_basketball_matchups_" + year2).find({}, {"_id": 0}).sort({"win_per": -1}).toArray(function(e, docs) {
 				//console.log(docs);
-				console.log("Displaying basketball matchup data...")
+				//console.log("Displaying basketball matchup data...")
 				disp_basketball_matchups = docs;
 				// call display to see if all finds are done
 				display(sports_number);
@@ -352,7 +352,7 @@ function owner_matchups(req, res, db, args, football_args, basketball_args, base
 	}	
 } // end of owner_matchups module
 
-function all_owner_matchups(req, res, db, args, football_args, basketball_args, baseball_args) {
+function all_owner_matchups(req, res, db, args) {
 
 	var disp_football_matchups = null;
 	var disp_basketball_matchups = null;
@@ -378,23 +378,10 @@ var complete = function() {
 
 	let owner_number = args.owner_number;
 
-	let completed_football_season = football_args.completed_football_season;
-	let this_football_season_started = football_args.this_football_season_started;
-	let this_football_completed_season = football_args.this_football_completed_season;
-	let football_completed_matchups = football_args.football_completed_matchups;
-	let football_ahead = football_args.football_ahead;
-	let football_ahead_completed_matchups = football_args.football_ahead_completed_matchups;
-
-	let completed_basketball_season = basketball_args.completed_basketball_season;
-	let this_basketball_season_started = basketball_args.this_basketball_season_started;
-	let basketball_completed_matchups = basketball_args.basketball_completed_matchups;
-	let this_basketball_completed_season = basketball_args.this_basketball_completed_season;
-
-	let completed_baseball_season = baseball_args.completed_baseball_season;
-	let this_baseball_season_started = baseball_args.this_baseball_season_started;
-	let baseball_completed_matchups = baseball_args.baseball_completed_matchups;
-	let this_baseball_completed_season = baseball_args.this_baseball_completed_season;
-
+	let completed_football_season = args.completed_football_season;
+	let completed_basketball_season = args.completed_basketball_season;
+	let completed_baseball_season = args.completed_baseball_season;
+/*
 	// determine in_season variable from season_started and completed_season variables
 	if (this_football_season_started == true && this_football_completed_season == false) {
 		var football_in_season = true;
@@ -435,9 +422,9 @@ var complete = function() {
 			football_in_season = false;
 		}
 	}	
-
+*/
 	var options = {
-		args: [owner_number, completed_football_season, football_in_season, completed_basketball_season, basketball_in_season, completed_baseball_season, baseball_in_season]
+		args: [owner_number, completed_football_season, completed_basketball_season, completed_baseball_season]
 	}
 
 	db.collection("owner" + owner_number).find({}, {"owner": 1, "_id": 0}).toArray(function(e, docs) {

--- a/app/routes/routes.js
+++ b/app/routes/routes.js
@@ -251,8 +251,26 @@ router.get('/owner_matchup_home_page', function(req, res) {
 	res.render('owner_matchup_home_page');
 })
 
-// route to individual owner's matchups for a given trifecta season
 router.get('/owner/:owner_number/matchups/:year1/:year2', function(req, res) {
+
+	let input = {
+		owner_number: req.params.owner_number,
+		current_year1: current_year1,
+		current_year2: current_year2,
+		year1: req.params.year1,
+		year2: req.params.year2,
+		this_football_completed_season: this_football_completed_season,
+		this_basketball_completed_season: this_basketball_completed_season,
+		this_baseball_completed_season: this_baseball_completed_season
+	};
+
+	const send = matchups_router.display_owner_matchups(req, res, db, input);
+
+
+})
+
+// route to individual owner's matchups for a given trifecta season
+router.get('/owner/:owner_number/matchups/:year1/:year2/scrape', function(req, res) {
 
 	var sports_list = [];
 
@@ -319,7 +337,7 @@ router.get('/owner/:owner_number/matchups/:year1/:year2', function(req, res) {
 }); // end of owner to owner matchups 
 
 // route to individual owner's matchups for all trifecta seasons
-router.get('/owner/:owner_number/matchups/all', function(req, res) {
+router.get('/owner/:owner_number/matchups/all/scrape', function(req, res) {
 
 	let owner_number = req.params.owner_number;
 

--- a/app/routes/routes.js
+++ b/app/routes/routes.js
@@ -337,7 +337,7 @@ router.get('/owner/:owner_number/matchups/:year1/:year2/scrape', function(req, r
 }); // end of owner to owner matchups 
 
 // route to individual owner's matchups for all trifecta seasons
-router.get('/owner/:owner_number/matchups/all/scrape', function(req, res) {
+router.get('/owner/:owner_number/matchups/all', function(req, res) {
 
 	let owner_number = req.params.owner_number;
 
@@ -346,33 +346,13 @@ router.get('/owner/:owner_number/matchups/all/scrape', function(req, res) {
 		//console.log(response.body);
 	
 		let input = {
-			owner_number: owner_number
+			owner_number: owner_number,
+			completed_football_season: completed_football_season,
+			completed_basketball_season: completed_basketball_season,
+			completed_baseball_season: completed_baseball_season
 		};
 		
-		var football_input = {
-			completed_football_season: completed_football_season,
-			this_football_season_started: this_football_season_started,
-			football_completed_matchups: football_completed_matchups,
-			this_football_completed_season: this_football_completed_season,
-			football_ahead: football_ahead,
-			football_ahead_completed_matchups: football_ahead_completed_matchups
-		};
-
-		var basketball_input = {
-			completed_basketball_season: completed_basketball_season,
-			this_basketball_season_started: this_basketball_season_started,
-			basketball_completed_matchups: basketball_completed_matchups,
-			this_basketball_completed_season: this_basketball_completed_season
-		};
-
-		var baseball_input = {
-			completed_baseball_season: completed_baseball_season,
-			this_baseball_season_started: this_baseball_season_started,
-			baseball_completed_matchups: baseball_completed_matchups,
-			this_baseball_completed_season: this_baseball_completed_season
-		};
-
-		const send = matchups_router.all_owner_matchups(req, res, db, input, football_input, basketball_input, baseball_input);	
+		const send = matchups_router.all_owner_matchups(req, res, db, input);	
 	}); // end of request to update current trifecta season's matchups before pulling total matchups
 }); // end of owner to owner matchups 
 

--- a/python/total_owner_matchups.py
+++ b/python/total_owner_matchups.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 ##### DEFINE FUNCTIONS #####
 
 # function that combines data from all matchup collections for total season trifecta owner matchup standings
-def matchupRecords(db, owner_number, completed_football_season, football_in_season, completed_basketball_season, basketball_in_season,  completed_baseball_season, baseball_in_season):
+def matchupRecords(db, owner_number, completed_football_season, completed_basketball_season, completed_baseball_season):
 
 	# pull owner name per owner number
 	collection_owner = "owner" + owner_number
@@ -23,12 +23,8 @@ def matchupRecords(db, owner_number, completed_football_season, football_in_seas
 
 	# set range of available seasons for football
 	starting_football_season = 2015;
-	if football_in_season == "true":
-		# add 2 because range is exclusive on back end
-		ending_football_season = int(completed_football_season) + 2
-	else:
-		# add 1 because end parameter in range is exclusive
-		ending_football_season = int(completed_football_season) + 1
+	# add 1 because end parameter in range is exclusive
+	ending_football_season = int(completed_football_season) + 1
 
 	football_seasons = range(starting_football_season, ending_football_season)
 	print "football_seasons", football_seasons
@@ -110,12 +106,8 @@ def matchupRecords(db, owner_number, completed_football_season, football_in_seas
 
 	# set range of available seasons for basketball
 	starting_basketball_season = 2016;
-	if basketball_in_season == "true":
-		# add 2 because range is exclusive on back end
-		ending_basketball_season = int(completed_basketball_season) + 2
-	else:
-		# add 1 because end parameter in range is exclusive
-		ending_basketball_season = int(completed_basketball_season) + 1
+	# add 1 because end parameter in range is exclusive
+	ending_basketball_season = int(completed_basketball_season) + 1
 
 	basketball_seasons = range(starting_basketball_season, ending_basketball_season)
 	#print "basketball_seasons", basketball_seasons
@@ -183,12 +175,8 @@ def matchupRecords(db, owner_number, completed_football_season, football_in_seas
 
 	# set range of available seasons for baseball
 	starting_baseball_season = 2016;
-	if baseball_in_season == "true":
-		# add 2 because range is exclusive on back end
-		ending_baseball_season = int(completed_baseball_season) + 2
-	else:
-		# add 1 because end parameter in range is exclusive
-		ending_baseball_season = int(completed_baseball_season) + 1
+	# add 1 because end parameter in range is exclusive
+	ending_baseball_season = int(completed_baseball_season) + 1
 
 	baseball_seasons = range(starting_baseball_season, ending_baseball_season)
 	#print "baseball_seasons", baseball_seasons
@@ -318,12 +306,7 @@ db = client.espn
 owner_number = str(sys.argv[1])
 
 completed_football_season = str(sys.argv[2])
-football_in_season = str(sys.argv[3])
+completed_basketball_season = str(sys.argv[3])
+completed_baseball_season = str(sys.argv[4])
 
-completed_basketball_season = str(sys.argv[4])
-basketball_in_season = str(sys.argv[5])
-
-completed_baseball_season = str(sys.argv[6])
-baseball_in_season = str(sys.argv[7])
-
-matchupRecords(db, owner_number, completed_football_season, football_in_season, completed_basketball_season, basketball_in_season, completed_baseball_season, baseball_in_season)
+matchupRecords(db, owner_number, completed_football_season, completed_basketball_season, completed_baseball_season)


### PR DESCRIPTION
Change matchups endpoint to only display, not scrape

Call /owner/:owner_number/matchups/:year1/:year2/scrape once at the end of the season for all matchups